### PR TITLE
AR-1929: Add Berksfile to load local recipes

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,6 @@
+source "https://supermarket.chef.io"
+
+Dir.glob('/home/ec2-user/cookbooks/*').each do |path|
+    cookbook File.basename(path), :path => path
+end
+


### PR DESCRIPTION
This has been tested and loads all cookbooks in /home/ec2-user/cookbooks as dependencies.